### PR TITLE
feat: introduce generic paged response typing

### DIFF
--- a/src/app/model/paged-response.ts
+++ b/src/app/model/paged-response.ts
@@ -1,0 +1,13 @@
+// src/app/model/paged-response.ts
+export interface PageInfo {
+  size: number; // page size
+  number: number; // current page, 0-based
+  totalElements: number;
+  totalPages: number;
+}
+
+export interface PagedResponse<T> {
+  content: T[];
+  page?: PageInfo;
+}
+

--- a/src/app/pages/punto-venta/punto-venta.ts
+++ b/src/app/pages/punto-venta/punto-venta.ts
@@ -113,7 +113,7 @@ export class PuntoVenta implements OnInit {
         })
       )
       .subscribe({
-        next: (lista) => {
+        next: (lista: ProductoData[] | null) => {
           if (!lista) return;
           this.productos = lista ?? [];
           this.productosFiltrados = [...this.productos];
@@ -181,7 +181,7 @@ export class PuntoVenta implements OnInit {
     this.productosFiltrados = [];
 
     this.productoSrv.buscarPorCategoria(idCategoria).subscribe({
-      next: (lista) => {
+      next: (lista: ProductoData[]) => {
         this.productos = lista ?? [];
         this.productosFiltrados = [...this.productos];
         this.cargandoProductos = false;

--- a/src/app/pages/socio/socio-informacion/socio-informacion.ts
+++ b/src/app/pages/socio/socio-informacion/socio-informacion.ts
@@ -5,20 +5,7 @@ import { finalize } from 'rxjs';
 import { MembresiaData } from '../../../model/membresia-data';
 import { MembresiaService } from '../../../services/membresia-service';
 import { FormsModule } from '@angular/forms';
-
-
-
-type PageInfo = {
-  size: number;
-  number: number;        // 0-based
-  totalElements: number;
-  totalPages: number;
-};
-
-type PagedResponse<T> = {
-  content: T[];
-  page: PageInfo;
-};
+import { PagedResponse } from '../../../model/paged-response';
 
 @Component({
   selector: 'app-socio-informacion',

--- a/src/app/pages/socio/socio.ts
+++ b/src/app/pages/socio/socio.ts
@@ -18,19 +18,7 @@ import { SocioData } from '../../model/socio-data';
 import { SocioModal } from './socio-modal/socio-modal';
 import { Router } from '@angular/router';
 import { NotificacionService } from '../../services/notificacion-service';
-
-// ─────────── Tipos de paginación del backend ───────────
-type PageInfo = {
-  size: number; // tamaño de página
-  number: number; // 0-based
-  totalElements: number;
-  totalPages: number;
-};
-
-type PagedResponse<T> = {
-  content: T[];
-  page: PageInfo;
-};
+import { PagedResponse } from '../../model/paged-response';
 
 @Component({
   selector: 'app-socio',

--- a/src/app/services/generic-service.ts
+++ b/src/app/services/generic-service.ts
@@ -1,5 +1,6 @@
 import { HttpClient, HttpHandler, HttpHeaders } from "@angular/common/http";
 import { Inject, Injectable } from "@angular/core";
+import { Observable } from 'rxjs';
 
 
 @Injectable({
@@ -20,16 +21,16 @@ export class GenericService <T> {
     return this.http.get<T>(`${this.url}/${id}`);
   }
 
-  guardar(t: T){
-    return this.http.post(this.url, t);
+  guardar(t: T): Observable<T> {
+    return this.http.post<T>(this.url, t);
   }
 
-  actualizar(id: number, t: T){
-    return this.http.put(`${this.url}/${id}`, t);
+  actualizar(id: number, t: T): Observable<T> {
+    return this.http.put<T>(`${this.url}/${id}`, t);
   }
 
-  eliminar(id: number){
-    return this.http.delete(`${this.url}/${id}`);
+  eliminar(id: number): Observable<void> {
+    return this.http.delete<void>(`${this.url}/${id}`);
   }
   
 }

--- a/src/app/services/membresia-service.ts
+++ b/src/app/services/membresia-service.ts
@@ -4,6 +4,7 @@ import { GenericService } from './generic-service';
 import { HttpClient } from '@angular/common/http';
 import { environment } from '../../environments/environment.development';
 import { MembresiaData } from '../model/membresia-data';
+import { PagedResponse } from '../model/paged-response';
 
 @Injectable({
   providedIn: 'root'
@@ -15,11 +16,11 @@ export class MembresiaService extends GenericService<MembresiaData> {
   }
 
   buscarMemebresiaPorSocio(idSocio: number,page: number, size:number){
-    return this.http.get<any>(`${this.url}/buscar/socio/${idSocio}?page=${page}&size=${size}`);
+    return this.http.get<PagedResponse<MembresiaData>>(`${this.url}/buscar/socio/${idSocio}?page=${page}&size=${size}`);
   }
 
   buscarMembresiasVigentesPorSocio(idSocio: number){
-    return this.http.get<any>(`${this.url}/por-socio/${idSocio}/vigentes`);
+    return this.http.get<MembresiaData[]>(`${this.url}/por-socio/${idSocio}/vigentes`);
   }
   
 }

--- a/src/app/services/producto-service.ts
+++ b/src/app/services/producto-service.ts
@@ -9,17 +9,17 @@ import { environment } from '../../environments/environment.development';
 })
 export class ProductoService  extends GenericService<ProductoData>{
 
-   constructor(protected override http: HttpClient){
+  constructor(protected override http: HttpClient){
     super(http, `${environment.HOST}/productos`,)
 
   }
 
   buscarPorCategoria(idCategoria:number){
-    return this.http.get<any>(`${this.url}/buscar/${idCategoria}`);
+    return this.http.get<ProductoData[]>(`${this.url}/buscar/${idCategoria}`);
   }
 
   buscarPorNombre(nombreProducto:string){
-    return this.http.get<any>(`${this.url}/buscar/nombre/${nombreProducto}`);
+    return this.http.get<ProductoData[]>(`${this.url}/buscar/nombre/${nombreProducto}`);
   }
   
 }

--- a/src/app/services/socio-service.ts
+++ b/src/app/services/socio-service.ts
@@ -1,6 +1,7 @@
 import { Injectable } from '@angular/core';
 import { GenericService } from './generic-service';
 import { SocioData } from '../model/socio-data';
+import { PagedResponse } from '../model/paged-response';
 import { HttpClient } from '@angular/common/http';
 import { environment } from '../../environments/environment.development';
 
@@ -15,11 +16,11 @@ export class SocioService extends GenericService<SocioData> {
 
 
   buscarSocios(page: number, size:number){
-    return this.http.get<any>(`${this.url}/buscar?page=${page}&size=${size}`);
+    return this.http.get<PagedResponse<SocioData>>(`${this.url}/buscar?page=${page}&size=${size}`);
   }
 
   buscarSociosPorNombre(nombre: string,page: number, size:number){
-    return this.http.get<any>(`${this.url}/buscar/${nombre}?page=${page}&size=${size}`);
+    return this.http.get<PagedResponse<SocioData>>(`${this.url}/buscar/${nombre}?page=${page}&size=${size}`);
   }
   
   


### PR DESCRIPTION
## Summary
- add reusable `PagedResponse<T>` model for backend pagination
- return typed observables from the generic service and domain services
- update components to consume typed responses from services

## Testing
- `npm run lint` *(fails: Missing script "lint")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b308bfbbe08326a6b2274955d29365