### PR TITLE
feat: incorporar respuesta paginada tipada

### DIFF
--- a/src/app/model/paged-response.ts
+++ b/src/app/model/paged-response.ts
@@ -1,0 +1,13 @@
+// src/app/model/paged-response.ts
+export interface InfoPagina {
+  tamanio: number; // tamaño de página
+  numero: number; // página actual, base 0
+  totalElementos: number;
+  totalPaginas: number;
+}
+
+export interface PagedResponse<T> {
+  contenido: T[];
+  pagina?: InfoPagina;
+}
+

--- a/src/app/pages/punto-venta/punto-venta.ts
+++ b/src/app/pages/punto-venta/punto-venta.ts
@@ -113,7 +113,7 @@ export class PuntoVenta implements OnInit {
         })
       )
       .subscribe({
-        next: (lista) => {
+        next: (lista: ProductoData[] | null) => {
           if (!lista) return;
           this.productos = lista ?? [];
           this.productosFiltrados = [...this.productos];
@@ -181,7 +181,7 @@ export class PuntoVenta implements OnInit {
     this.productosFiltrados = [];
 
     this.productoSrv.buscarPorCategoria(idCategoria).subscribe({
-      next: (lista) => {
+      next: (lista: ProductoData[]) => {
         this.productos = lista ?? [];
         this.productosFiltrados = [...this.productos];
         this.cargandoProductos = false;

--- a/src/app/pages/socio/socio-informacion/socio-informacion.ts
+++ b/src/app/pages/socio/socio-informacion/socio-informacion.ts
@@ -5,20 +5,7 @@ import { finalize } from 'rxjs';
 import { MembresiaData } from '../../../model/membresia-data';
 import { MembresiaService } from '../../../services/membresia-service';
 import { FormsModule } from '@angular/forms';
-
-
-
-type PageInfo = {
-  size: number;
-  number: number;        // 0-based
-  totalElements: number;
-  totalPages: number;
-};
-
-type PagedResponse<T> = {
-  content: T[];
-  page: PageInfo;
-};
+import { PagedResponse } from '../../../model/paged-response';
 
 @Component({
   selector: 'app-socio-informacion',
@@ -72,18 +59,18 @@ export class SocioInformacion implements OnInit {
     this.cargando = true;
     this.error = null;
 
-    this.membresiaSrv.buscarMemebresiaPorSocio(this.idSocio, this.pagina, this.tamanio)
+    this.membresiaSrv.buscarMembresiasPorSocio(this.idSocio, this.pagina, this.tamanio)
       .pipe(finalize(() => this.cargando = false))
       .subscribe({
         next: (resp: PagedResponse<MembresiaData>) => {
-          this.movimientos = resp.content ?? [];
-          this.totalPaginas = resp.page?.totalPages ?? 0;
-          this.totalElementos = resp.page?.totalElements ?? 0;
-          this.tamanio = resp.page?.size ?? this.tamanio;
-          this.pagina = resp.page?.number ?? this.pagina;
+          this.movimientos = resp.contenido ?? [];
+          this.totalPaginas = resp.pagina?.totalPaginas ?? 0;
+          this.totalElementos = resp.pagina?.totalElementos ?? 0;
+          this.tamanio = resp.pagina?.tamanio ?? this.tamanio;
+          this.pagina = resp.pagina?.numero ?? this.pagina;
 
           // Rellena encabezado con el primer registro (si existe)
-          const s = this.movimientos[0]?.socio as any;
+          const s = this.movimientos[0]?.socio;
           this.socioNombre = s ? `${s.nombre} ${s.apellido}` : null;
           this.socioTelefono = s?.telefono ?? null;
 

--- a/src/app/pages/socio/socio.ts
+++ b/src/app/pages/socio/socio.ts
@@ -18,19 +18,7 @@ import { SocioData } from '../../model/socio-data';
 import { SocioModal } from './socio-modal/socio-modal';
 import { Router } from '@angular/router';
 import { NotificacionService } from '../../services/notificacion-service';
-
-// ─────────── Tipos de paginación del backend ───────────
-type PageInfo = {
-  size: number; // tamaño de página
-  number: number; // 0-based
-  totalElements: number;
-  totalPages: number;
-};
-
-type PagedResponse<T> = {
-  content: T[];
-  page: PageInfo;
-};
+import { PagedResponse } from '../../model/paged-response';
 
 @Component({
   selector: 'app-socio',
@@ -118,11 +106,11 @@ export class Socio implements OnInit, OnDestroy {
 
   // ─────────── Carga y manejo de respuestas ───────────
   private aplicarRespuesta(resp: PagedResponse<SocioData>): void {
-    this.listaSocios = resp.content ?? [];
-    this.totalPaginas = resp.page?.totalPages ?? 0;
-    this.totalElementos = resp.page?.totalElements ?? 0;
-    this.tamanioPagina = resp.page?.size ?? this.tamanioPagina;
-    this.paginaActual = resp.page?.number ?? this.paginaActual;
+    this.listaSocios = resp.contenido ?? [];
+    this.totalPaginas = resp.pagina?.totalPaginas ?? 0;
+    this.totalElementos = resp.pagina?.totalElementos ?? 0;
+    this.tamanioPagina = resp.pagina?.tamanio ?? this.tamanioPagina;
+    this.paginaActual = resp.pagina?.numero ?? this.paginaActual;
 
     // Si quedó vacía la página actual (p.ej. tras eliminar), retrocede una y recarga.
     if (this.listaSocios.length === 0 && this.paginaActual > 0) {

--- a/src/app/services/generic-service.ts
+++ b/src/app/services/generic-service.ts
@@ -1,5 +1,6 @@
 import { HttpClient, HttpHandler, HttpHeaders } from "@angular/common/http";
 import { Inject, Injectable } from "@angular/core";
+import { Observable } from 'rxjs';
 
 
 @Injectable({
@@ -12,24 +13,24 @@ export class GenericService <T> {
     @Inject("url") protected url: string
   ) { }
 
-  buscarTodos(){
+  buscarTodos(): Observable<T[]> {
     return this.http.get<T[]>(this.url);
   }
 
-  buscarPorId(id: number){
+  buscarPorId(id: number): Observable<T> {
     return this.http.get<T>(`${this.url}/${id}`);
   }
 
-  guardar(t: T){
-    return this.http.post(this.url, t);
+  guardar(entidad: T): Observable<T> {
+    return this.http.post<T>(this.url, entidad);
   }
 
-  actualizar(id: number, t: T){
-    return this.http.put(`${this.url}/${id}`, t);
+  actualizar(id: number, entidad: T): Observable<T> {
+    return this.http.put<T>(`${this.url}/${id}`, entidad);
   }
 
-  eliminar(id: number){
-    return this.http.delete(`${this.url}/${id}`);
+  eliminar(id: number): Observable<void> {
+    return this.http.delete<void>(`${this.url}/${id}`);
   }
   
 }

--- a/src/app/services/membresia-service.ts
+++ b/src/app/services/membresia-service.ts
@@ -4,6 +4,8 @@ import { GenericService } from './generic-service';
 import { HttpClient } from '@angular/common/http';
 import { environment } from '../../environments/environment.development';
 import { MembresiaData } from '../model/membresia-data';
+import { PagedResponse } from '../model/paged-response';
+import { Observable } from 'rxjs';
 
 @Injectable({
   providedIn: 'root'
@@ -14,12 +16,12 @@ export class MembresiaService extends GenericService<MembresiaData> {
     super(http, `${environment.HOST}/membresias`)
   }
 
-  buscarMemebresiaPorSocio(idSocio: number,page: number, size:number){
-    return this.http.get<any>(`${this.url}/buscar/socio/${idSocio}?page=${page}&size=${size}`);
+  buscarMembresiasPorSocio(idSocio: number, pagina: number, tamanio: number): Observable<PagedResponse<MembresiaData>>{
+    return this.http.get<PagedResponse<MembresiaData>>(`${this.url}/buscar/socio/${idSocio}?page=${pagina}&size=${tamanio}`);
   }
 
-  buscarMembresiasVigentesPorSocio(idSocio: number){
-    return this.http.get<any>(`${this.url}/por-socio/${idSocio}/vigentes`);
+  buscarMembresiasVigentesPorSocio(idSocio: number): Observable<MembresiaData[]>{
+    return this.http.get<MembresiaData[]>(`${this.url}/por-socio/${idSocio}/vigentes`);
   }
   
 }

--- a/src/app/services/producto-service.ts
+++ b/src/app/services/producto-service.ts
@@ -9,17 +9,17 @@ import { environment } from '../../environments/environment.development';
 })
 export class ProductoService  extends GenericService<ProductoData>{
 
-   constructor(protected override http: HttpClient){
+  constructor(protected override http: HttpClient){
     super(http, `${environment.HOST}/productos`,)
 
   }
 
   buscarPorCategoria(idCategoria:number){
-    return this.http.get<any>(`${this.url}/buscar/${idCategoria}`);
+    return this.http.get<ProductoData[]>(`${this.url}/buscar/${idCategoria}`);
   }
 
   buscarPorNombre(nombreProducto:string){
-    return this.http.get<any>(`${this.url}/buscar/nombre/${nombreProducto}`);
+    return this.http.get<ProductoData[]>(`${this.url}/buscar/nombre/${nombreProducto}`);
   }
   
 }

--- a/src/app/services/socio-service.ts
+++ b/src/app/services/socio-service.ts
@@ -1,8 +1,10 @@
 import { Injectable } from '@angular/core';
 import { GenericService } from './generic-service';
 import { SocioData } from '../model/socio-data';
+import { PagedResponse } from '../model/paged-response';
 import { HttpClient } from '@angular/common/http';
 import { environment } from '../../environments/environment.development';
+import { Observable } from 'rxjs';
 
 @Injectable({
   providedIn: 'root'
@@ -14,12 +16,12 @@ export class SocioService extends GenericService<SocioData> {
   }
 
 
-  buscarSocios(page: number, size:number){
-    return this.http.get<any>(`${this.url}/buscar?page=${page}&size=${size}`);
+  buscarSocios(pagina: number, tamanio: number): Observable<PagedResponse<SocioData>>{
+    return this.http.get<PagedResponse<SocioData>>(`${this.url}/buscar?page=${pagina}&size=${tamanio}`);
   }
 
-  buscarSociosPorNombre(nombre: string,page: number, size:number){
-    return this.http.get<any>(`${this.url}/buscar/${nombre}?page=${page}&size=${size}`);
+  buscarSociosPorNombre(nombre: string, pagina: number, tamanio: number): Observable<PagedResponse<SocioData>>{
+    return this.http.get<PagedResponse<SocioData>>(`${this.url}/buscar/${nombre}?page=${pagina}&size=${tamanio}`);
   }
   
   


### PR DESCRIPTION
## Resumen
- usar `PagedResponse<T>` con campos en español para manejar datos paginados
- exponer métodos de servicios con parámetros `pagina` y `tamanio`
- consumir las nuevas propiedades `contenido` y `pagina` en componentes de socio

## Pruebas
- `npm run lint` *(falla: Missing script "lint")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b308bfbbe08326a6b2274955d29365