### PR TITLE
feat: add generic search methods

### DIFF
--- a/src/app/pages/asistencia/asistencia.ts
+++ b/src/app/pages/asistencia/asistencia.ts
@@ -102,7 +102,7 @@ export class Asistencia implements OnInit {
       error: () => { this.error = 'No se pudo cargar el socio.'; this.cargando = false; }
     });
 
-    this.membresiaSrv.buscarMembresiasVigentesPorSocio(id).subscribe({
+    this.membresiaSrv.buscar({ idSocio: id, vigentes: true }).subscribe({
       next: (lista: MembresiaData[]) => {
         this.store.guardarEstado(id, this.socio(), lista ?? []);
         this.cargando = false;

--- a/src/app/pages/punto-venta/punto-venta.ts
+++ b/src/app/pages/punto-venta/punto-venta.ts
@@ -94,7 +94,8 @@ export class PuntoVenta implements OnInit {
             this.categoriaActivaId = null;      // búsqueda libre
             this.cargandoProductos = true;
             this.productoSeleccionado = null;
-            return this.productoSrv.buscarPorNombre(t)
+            return this.productoSrv
+              .buscar({ nombre: t })
               .pipe(finalize(() => (this.cargandoProductos = false)));
           }
           if (t.length === 0) {
@@ -180,7 +181,7 @@ export class PuntoVenta implements OnInit {
     this.productos = [];
     this.productosFiltrados = [];
 
-    this.productoSrv.buscarPorCategoria(idCategoria).subscribe({
+    this.productoSrv.buscar({ idCategoria }).subscribe({
       next: (lista: ProductoData[]) => {
         this.productos = lista ?? [];
         this.productosFiltrados = [...this.productos];

--- a/src/app/pages/socio/socio-informacion/socio-informacion.ts
+++ b/src/app/pages/socio/socio-informacion/socio-informacion.ts
@@ -59,7 +59,8 @@ export class SocioInformacion implements OnInit {
     this.cargando = true;
     this.error = null;
 
-    this.membresiaSrv.buscarMembresiasPorSocio(this.idSocio, this.pagina, this.tamanio)
+    this.membresiaSrv
+      .buscarPaginado(this.pagina, this.tamanio, { idSocio: this.idSocio })
       .pipe(finalize(() => this.cargando = false))
       .subscribe({
         next: (resp: PagedResponse<MembresiaData>) => {

--- a/src/app/pages/socio/socio.ts
+++ b/src/app/pages/socio/socio.ts
@@ -77,7 +77,7 @@ export class Socio implements OnInit, OnDestroy {
           this.mensajeError = null;
           this.paginaActual = 0; // nueva búsqueda => desde la primera página
           return this.socioService
-            .buscarSociosPorNombre(texto, this.paginaActual, this.tamanioPagina)
+            .buscarPaginado(this.paginaActual, this.tamanioPagina, { nombre: texto })
             .pipe(finalize(() => (this.cargando = false)));
         })
       )
@@ -126,12 +126,8 @@ export class Socio implements OnInit, OnDestroy {
     const texto = this.terminoBusqueda.trim();
     const fuente$ =
       texto.length >= this.minCaracteresBusqueda
-        ? this.socioService.buscarSociosPorNombre(
-            texto,
-            this.paginaActual,
-            this.tamanioPagina
-          )
-        : this.socioService.buscarSocios(this.paginaActual, this.tamanioPagina);
+        ? this.socioService.buscarPaginado(this.paginaActual, this.tamanioPagina, { nombre: texto })
+        : this.socioService.buscarPaginado(this.paginaActual, this.tamanioPagina);
 
     fuente$.pipe(finalize(() => (this.cargando = false))).subscribe({
       next: (resp: PagedResponse<SocioData>) => this.aplicarRespuesta(resp),

--- a/src/app/services/generic-service.ts
+++ b/src/app/services/generic-service.ts
@@ -1,6 +1,7 @@
-import { HttpClient } from "@angular/common/http";
+import { HttpClient, HttpParams } from "@angular/common/http";
 import { Inject, Injectable } from "@angular/core";
 import { Observable } from 'rxjs';
+import { PagedResponse } from '../model/paged-response';
 
 
 @Injectable({
@@ -31,6 +32,30 @@ export class GenericService <T> {
 
   eliminar(id: number): Observable<void> {
     return this.http.delete<void>(`${this.url}/${id}`);
+  }
+
+  buscar(params: HttpParams | Record<string, any>): Observable<T[]> {
+    const httpParams =
+      params instanceof HttpParams ? params : new HttpParams({ fromObject: params });
+    return this.http.get<T[]>(`${this.url}/buscar`, { params: httpParams });
+  }
+
+  buscarPaginado(
+    pagina: number,
+    tamanio: number,
+    params?: Record<string, any>
+  ): Observable<PagedResponse<T>> {
+    let httpParams = new HttpParams().set('page', pagina).set('size', tamanio);
+
+    if (params) {
+      Object.entries(params).forEach(([k, v]) => {
+        if (v !== undefined && v !== null) {
+          httpParams = httpParams.set(k, String(v));
+        }
+      });
+    }
+
+    return this.http.get<PagedResponse<T>>(`${this.url}/buscar`, { params: httpParams });
   }
   
 }

--- a/src/app/services/membresia-service.ts
+++ b/src/app/services/membresia-service.ts
@@ -4,8 +4,6 @@ import { GenericService } from './generic-service';
 import { HttpClient } from '@angular/common/http';
 import { environment } from '../../environments/environment.development';
 import { MembresiaData } from '../model/membresia-data';
-import { PagedResponse } from '../model/paged-response';
-import { Observable } from 'rxjs';
 
 @Injectable({
   providedIn: 'root'
@@ -15,13 +13,4 @@ export class MembresiaService extends GenericService<MembresiaData> {
   constructor(protected override http: HttpClient){
     super(http, `${environment.HOST}/membresias`)
   }
-
-  buscarMembresiasPorSocio(idSocio: number, pagina: number, tamanio: number): Observable<PagedResponse<MembresiaData>>{
-    return this.http.get<PagedResponse<MembresiaData>>(`${this.url}/buscar/socio/${idSocio}?page=${pagina}&size=${tamanio}`);
-  }
-
-  buscarMembresiasVigentesPorSocio(idSocio: number): Observable<MembresiaData[]>{
-    return this.http.get<MembresiaData[]>(`${this.url}/por-socio/${idSocio}/vigentes`);
-  }
-  
 }

--- a/src/app/services/producto-service.ts
+++ b/src/app/services/producto-service.ts
@@ -10,16 +10,6 @@ import { environment } from '../../environments/environment.development';
 export class ProductoService  extends GenericService<ProductoData>{
 
   constructor(protected override http: HttpClient){
-    super(http, `${environment.HOST}/productos`,)
-
+    super(http, `${environment.HOST}/productos`)
   }
-
-  buscarPorCategoria(idCategoria:number){
-    return this.http.get<ProductoData[]>(`${this.url}/buscar/${idCategoria}`);
-  }
-
-  buscarPorNombre(nombreProducto:string){
-    return this.http.get<ProductoData[]>(`${this.url}/buscar/nombre/${nombreProducto}`);
-  }
-  
 }

--- a/src/app/services/socio-service.ts
+++ b/src/app/services/socio-service.ts
@@ -1,10 +1,8 @@
 import { Injectable } from '@angular/core';
 import { GenericService } from './generic-service';
 import { SocioData } from '../model/socio-data';
-import { PagedResponse } from '../model/paged-response';
 import { HttpClient } from '@angular/common/http';
 import { environment } from '../../environments/environment.development';
-import { Observable } from 'rxjs';
 
 @Injectable({
   providedIn: 'root'
@@ -15,14 +13,4 @@ export class SocioService extends GenericService<SocioData> {
     super(http, `${environment.HOST}/socios`)
   }
 
-
-  buscarSocios(pagina: number, tamanio: number): Observable<PagedResponse<SocioData>>{
-    return this.http.get<PagedResponse<SocioData>>(`${this.url}/buscar?page=${pagina}&size=${tamanio}`);
-  }
-
-  buscarSociosPorNombre(nombre: string, pagina: number, tamanio: number): Observable<PagedResponse<SocioData>>{
-    return this.http.get<PagedResponse<SocioData>>(`${this.url}/buscar/${nombre}?page=${pagina}&size=${tamanio}`);
-  }
-  
-  
 }


### PR DESCRIPTION
## Summary
- add reusable `buscar` and `buscarPaginado` to generic service using `HttpParams`
- rely on generic search from socio, membresia and producto services
- update components to query via the new generic API

## Testing
- `npm test -- --watch=false` *(fails: No binary for Chrome browser on your platform)*

------
https://chatgpt.com/codex/tasks/task_e_68b3142a8fe483269b2c554694e775b3