### PR TITLE
feat: share generic CRUD list behavior

### DIFF
--- a/src/app/pages/paquete/paquete.html
+++ b/src/app/pages/paquete/paquete.html
@@ -3,7 +3,7 @@
   <h1 class="text-2xl font-bold text-ra-slate">Paquetes</h1>
 
   <button
-    (click)="abrirModalParaCrear()"
+    (click)="abrirCrear()"
     class="inline-flex items-center gap-2 px-4 py-2 rounded-md bg-ra-azul-fuerte text-ra-white hover:bg-ra-green2 shadow-card">
     <img src="/iconos/agregar.svg" alt="" class="w-5 h-5">
     <span>Agregar paquete</span>
@@ -28,15 +28,15 @@
     </thead>
 
     <tbody>
-      @if (estaCargando) {
+      @if (loading) {
         <tr><td colspan="5" class="py-6 px-6 text-center text-ra-slate">Cargando…</td></tr>
-      } @else if (mensajeError) {
-        <tr><td colspan="5" class="py-6 px-6 text-center text-red-600">{{ mensajeError }}</td></tr>
+      } @else if (error) {
+        <tr><td colspan="5" class="py-6 px-6 text-center text-red-600">{{ error }}</td></tr>
       } @else {
-        @if (listaPaquetes.length === 0) {
+        @if (items.length === 0) {
           <tr><td colspan="5" class="py-6 px-6 text-center text-ra-slate">Sin resultados.</td></tr>
         } @else {
-          @for (p of listaPaquetes; track p.idPaquete) {
+          @for (p of items; track p.idPaquete) {
             <tr class="border-t border-ra-grayLight/60 hover:bg-ra-bg">
               <td class="py-4 px-6 text-left truncate">{{ p.nombre }}</td>
               <td class="py-4 px-6 text-center">{{ p.tiempo | tiempoPlan}}</td>
@@ -44,10 +44,10 @@
               <td class="py-4 px-6 text-center text-sm">{{ p.costoInscripcion | currency:'MXN':'symbol-narrow':'1.2-2' }}</td>
               <td class="py-2 px-6">
                 <div class="flex items-center justify-center gap-2">
-                  <button (click)="abrirModalParaEditar(p)" class="p-2 rounded hover:bg-ra-grayLight/40" title="Editar">
+                  <button (click)="abrirEditar(p)" class="p-2 rounded hover:bg-ra-grayLight/40" title="Editar">
                     <img src="/iconos/editar.svg" alt="Editar" class="w-5 h-5" />
                   </button>
-                  <button (click)="eliminarPaquete(p)" class="p-2 rounded hover:bg-ra-grayLight/40" title="Eliminar">
+                  <button (click)="eliminar(p)" class="p-2 rounded hover:bg-ra-grayLight/40" title="Eliminar">
                     <img src="/iconos/eliminar.svg" alt="Eliminar" class="w-5 h-5" />
                   </button>
                 </div>
@@ -61,17 +61,17 @@
 </div>
 
 <!-- Modal -->
-@if (mostrarModalPaquete()) {
+@if (mostrarModal()) {
   <div class="fixed inset-0 z-50 flex items-center justify-center">
     <!-- Backdrop -->
-    <div class="absolute inset-0 bg-black/50" (click)="cerrarModalPaquete()"></div>
+    <div class="absolute inset-0 bg-black/50" (click)="cerrarModal()"></div>
 
     <!-- Contenedor modal -->
     <div class="relative z-10 w-full max-w-lg mx-4">
       <div class="bg-ra-white rounded-xl2 shadow-card">
         <app-paquete-modal
-          [paquete]="paqueteEnEdicion"
-          (cancelar)="cerrarModalPaquete()"
+          [paquete]="itemEditando"
+          (cancelar)="cerrarModal()"
           (guardado)="despuesDeGuardar()">
         </app-paquete-modal>
       </div>

--- a/src/app/pages/producto/producto.html
+++ b/src/app/pages/producto/producto.html
@@ -60,12 +60,12 @@
             <tr>
                 <td colspan="8" class="py-6 px-6 text-center text-red-600">{{ error }}</td>
             </tr>
-            } @else if (productos.length === 0) {
+            } @else if (items.length === 0) {
             <tr>
                 <td colspan="8" class="py-6 px-6 text-center text-ra-slate">Sin resultados.</td>
             </tr>
             } @else {
-            @for (p of productos; track p.idProducto) {
+            @for (p of items; track p.idProducto) {
             <tr class="border-t border-ra-grayLight/60 hover:bg-ra-bg text-center">
                 <td class="py-3 px-6 text-center">{{ p.idProducto }}</td>
                 <td class="py-3 px-6 truncate">{{ p.nombre }}</td>
@@ -86,7 +86,7 @@
                 <td class="py-2 px-3">
                     <div class="flex items-center justify-center gap-2">
                         <!-- Editar (SVG inline) -->
-                        <button (click)="editar(p)" class="p-2 rounded hover:bg-ra-grayLight/40" title="Editar">
+                        <button (click)="abrirEditar(p)" class="p-2 rounded hover:bg-ra-grayLight/40" title="Editar">
                             <img src="/iconos/editar.svg" alt="Editar" class="w-9 h-9" />
                         </button>
                         <!-- Eliminar (SVG inline) -->
@@ -108,7 +108,7 @@
     <div class="absolute inset-0 bg-black/50" (click)="cerrarModal()"></div>
     <div class="relative z-10 w-full max-w-2xl mx-4">
         <div class="bg-ra-white rounded-xl2 shadow-card">
-            <app-producto-modal [producto]="productoEditando" (cancelar)="cerrarModal()" (guardado)="onGuardado()">
+            <app-producto-modal [producto]="itemEditando" (cancelar)="cerrarModal()" (guardado)="despuesDeGuardar()">
             </app-producto-modal>
         </div>
     </div>

--- a/src/app/shared/base-crud-list.component.ts
+++ b/src/app/shared/base-crud-list.component.ts
@@ -1,0 +1,90 @@
+import { signal } from '@angular/core';
+import { GenericService } from '../services/generic-service';
+import { NotificacionService } from '../services/notificacion-service';
+
+/**
+ * Clase base con la lógica común de los listados que utilizan
+ * un modal para crear y editar elementos.
+ */
+export abstract class BaseCrudListComponent<T> {
+  /** Lista de elementos cargados desde el backend. */
+  items: T[] = [];
+
+  /** Indicador de carga en proceso. */
+  loading = true;
+
+  /** Mensaje de error si la carga falla. */
+  error: string | null = null;
+
+  /** Controla la visibilidad del modal. */
+  mostrarModal = signal(false);
+
+  /** Elemento que se está editando actualmente. */
+  itemEditando: T | null = null;
+
+  constructor(
+    protected service: GenericService<T>,
+    protected notify?: NotificacionService
+  ) {}
+
+  /** Carga la lista de elementos desde el servicio. */
+  cargar(): void {
+    this.loading = true;
+    this.error = null;
+    this.service.buscarTodos().subscribe({
+      next: (data) => {
+        this.items = data ?? [];
+        this.loading = false;
+      },
+      error: () => {
+        this.loading = false;
+        this.error = 'No se pudo cargar la lista.';
+      },
+    });
+  }
+
+  /** Abre el modal en modo creación. */
+  abrirCrear(): void {
+    this.itemEditando = null;
+    this.mostrarModal.set(true);
+  }
+
+  /** Abre el modal para editar el elemento indicado. */
+  abrirEditar(item: T): void {
+    this.itemEditando = item;
+    this.mostrarModal.set(true);
+  }
+
+  /** Cierra el modal. */
+  cerrarModal(): void {
+    this.mostrarModal.set(false);
+  }
+
+  /**
+   * Se debe llamar después de guardar para recargar la lista y cerrar el modal.
+   */
+  despuesDeGuardar(): void {
+    this.cerrarModal();
+    this.cargar();
+  }
+
+  /** Elimina el elemento indicado tras confirmar. */
+  eliminar(item: T): void {
+    const id = this.getId(item);
+    if (id == null) return;
+    if (!confirm(this.getMensajeConfirmacion(item))) return;
+    this.service.eliminar(id).subscribe({
+      next: () => this.cargar(),
+      error: () => this.notify?.error('No se pudo eliminar.'),
+    });
+  }
+
+  /** Obtiene el identificador del elemento. */
+  protected abstract getId(item: T): number | undefined;
+
+  /** Mensaje mostrado al confirmar eliminación. */
+  protected getMensajeConfirmacion(_item: T): string {
+    return '¿Eliminar elemento?';
+  }
+}
+


### PR DESCRIPTION
## Summary
- add BaseCrudListComponent with reusable list logic
- refactor Producto and Paquete lists to extend the new base class

## Testing
- `npm test` *(fails: No binary for Chrome browser on your platform)*

------
https://chatgpt.com/codex/tasks/task_e_68b3143fa94483268268540911546fa5